### PR TITLE
Add banner

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,11 @@ import (
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "spare",
-		Short: "spare deploy single page application and aws infrastructure",
+		Short: "spare release single page application and aws infrastructure",
+		Long: `,___,
+[OvO] SPARE - Single Page Application Release Easily
+/)__)         https://github.com/nao1215/spare (MIT LICENSE)
+-"--"-`,
 	}
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SilenceUsage = true


### PR DESCRIPTION
```
$ ./spare 
,___,
[OvO] SPARE - Single Page Application Release Easily
/)__)         https://github.com/nao1215/spare (MIT LICENSE)
-"--"-

Usage:
  spare [command]

Available Commands:
  bug-report  Submit a bug report at GitHub
  help        Help about any command
  init        Generate .spare.yml at current directory
  version     Show spare command version information

Flags:
  -h, --help   help for spare

Use "spare [command] --help" for more information about a command.
```